### PR TITLE
Codex/fix cli export locale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1333,7 +1333,7 @@
       }
     },
     "packages/create-apiops": {
-      "version": "0.1.0",
+      "version": "1.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apiops-cycles-method-data",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apiops-cycles-method-data",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "release:create-apiops:publish": "npm publish --workspace packages/create-apiops --access public",
     "check:packaging:skills": "node scripts/check-packaging-skills.mjs",
     "check:package:contents": "node scripts/check-package-contents.mjs",
-    "test:create-apiops": "node scripts/test-create-apiops-scaffold.mjs"
+    "test:create-apiops": "node scripts/test-create-apiops-scaffold.mjs && node scripts/test-method-cli.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apiops-cycles-method-data",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "APIOps Cycles Method data and canvases",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/create-apiops/bin/create-apiops-project.js
+++ b/packages/create-apiops/bin/create-apiops-project.js
@@ -97,10 +97,32 @@ function replaceInFile(filePath, replacements) {
   fs.writeFileSync(filePath, content);
 }
 
+function resolveNpmCommand() {
+  const npmCliPath = path.resolve(path.dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js");
+  if (fs.existsSync(npmCliPath)) {
+    return {
+      command: process.execPath,
+      args: [npmCliPath]
+    };
+  }
+
+  return {
+    command: process.platform === "win32" ? "npm.cmd" : "npm",
+    args: []
+  };
+}
+
+function runCommand(command, args, options = {}) {
+  return spawnSync(command, args, {
+    shell: false,
+    ...options
+  });
+}
+
 function getScripts(locale, apiStyle) {
   const base = {
     "method": "node ./node_modules/apiops-cycles-method-data/packages/create-apiops/bin/method-cli.js",
-    "method:start": `node ./node_modules/apiops-cycles-method-data/packages/create-apiops/bin/method-cli.js start --locale ${locale}`,
+    "method:start": `node ./node_modules/apiops-cycles-method-data/packages/create-apiops/bin/method-cli.js start --default-locale ${locale}`,
     "method:resources:strategy": `node ./node_modules/apiops-cycles-method-data/packages/create-apiops/bin/method-cli.js resources --station api-product-strategy --locale ${locale}`,
     "method:canvases:new-api": `node ./node_modules/apiops-cycles-method-data/packages/create-apiops/bin/method-cli.js generate-canvases --preset new-api --style "${apiStyle}" --locale ${locale} --output ./specs/canvases`,
     "method:stations": `node ./node_modules/apiops-cycles-method-data/skills/new-api-guide/scripts/get-core-stations.cjs ${locale}`,
@@ -200,18 +222,18 @@ async function main() {
   console.log(`Created ${projectName}`);
 
   if (installNow) {
-    const result = spawnSync("npm", ["install"], {
+    const npmCommand = resolveNpmCommand();
+    const result = runCommand(npmCommand.command, [...npmCommand.args, "install"], {
       cwd: targetDir,
-      stdio: "inherit",
-      shell: true
+      stdio: "inherit"
     });
     if (result.status !== 0) {
       console.error("npm install failed");
       process.exit(result.status || 1);
     }
 
-    const canvasInit = spawnSync(
-      "node",
+    const canvasInit = runCommand(
+      process.execPath,
       [
         "./node_modules/apiops-cycles-method-data/packages/create-apiops/bin/method-cli.js",
         "generate-canvases",
@@ -222,8 +244,7 @@ async function main() {
       ],
       {
         cwd: targetDir,
-        stdio: "inherit",
-        shell: true
+        stdio: "inherit"
       }
     );
 

--- a/packages/create-apiops/bin/method-cli.js
+++ b/packages/create-apiops/bin/method-cli.js
@@ -18,12 +18,13 @@ const STATION_SCRIPT_HINTS = {
 
 function printUsage() {
   console.log(`Usage:
-  node packages/create-apiops/bin/method-cli.js start [--locale <locale>] [--json] [--list] [--answers <yes,no,...>] [--next-action <resources|canvases|exit>]
+  node packages/create-apiops/bin/method-cli.js start [--locale <locale>] [--default-locale <locale>] [--json] [--list] [--answers <yes,no,...>] [--next-action <resources|canvases|exit>]
   node packages/create-apiops/bin/method-cli.js resources --station <station-id> [--locale <locale>] [--style <style>] [--json] [--list] [--step-actions <details,next,...>]
   node packages/create-apiops/bin/method-cli.js generate-canvases [--station <station-id> | --stations <ids> | --preset new-api] [--locale <locale>] [--style <style>] [--output <dir>] [--force] [--json]
 
 Examples:
   node packages/create-apiops/bin/method-cli.js start --locale en
+  node packages/create-apiops/bin/method-cli.js start --default-locale en
   node packages/create-apiops/bin/method-cli.js start --locale en --answers yes,no,yes --next-action resources
   node packages/create-apiops/bin/method-cli.js resources --station api-product-strategy --locale en
   node packages/create-apiops/bin/method-cli.js generate-canvases --preset new-api --style REST --output ./specs/canvases
@@ -69,6 +70,14 @@ function parseArgs(argv) {
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function runCommand(command, args, options = {}) {
+  return spawnSync(command, args, {
+    encoding: "utf8",
+    shell: false,
+    ...options
+  });
 }
 
 function getNextStepHints(stationId) {
@@ -155,44 +164,137 @@ async function fillCanvasSectionsInteractive(stationId, step, locale, output, rl
 }
 
 function resolveCanvasExportCommand() {
-  const binPath = path.resolve(
-    process.cwd(),
-    "node_modules",
-    ".bin",
-    process.platform === "win32" ? "canvascreator-export.cmd" : "canvascreator-export"
-  );
-  if (fs.existsSync(binPath)) {
+  const packageRoot = path.resolve(process.cwd(), "node_modules", "canvascreator");
+  if (!fs.existsSync(packageRoot)) {
     return {
-      command: binPath,
-      args: []
+      ok: false,
+      reason: "SVG export requires CanvasCreator export support, which is not installed in this project.",
+      help: "Run `npm install` to install project dependencies, or `npm install canvascreator` to add CanvasCreator manually."
     };
   }
 
-  const scriptPath = path.resolve(process.cwd(), "node_modules", "canvascreator", "scripts", "export.js");
+  const packageJsonPath = path.join(packageRoot, "package.json");
+  if (fs.existsSync(packageJsonPath)) {
+    const packageJson = readJson(packageJsonPath);
+    const binEntry = typeof packageJson.bin === "string"
+      ? packageJson.bin
+      : packageJson.bin?.["canvascreator-export"];
+
+    if (binEntry) {
+      const binPath = path.resolve(packageRoot, binEntry);
+      if (fs.existsSync(binPath)) {
+        return {
+          ok: true,
+          command: process.execPath,
+          args: [binPath]
+        };
+      }
+    }
+  }
+
+  const scriptPath = path.resolve(packageRoot, "scripts", "export.js");
   if (fs.existsSync(scriptPath)) {
     return {
+      ok: true,
       command: process.execPath,
       args: [scriptPath]
     };
   }
 
-  return null;
+  return {
+    ok: false,
+    reason: "CanvasCreator is installed, but its export CLI could not be found.",
+    help: "Reinstall `canvascreator` or use the CanvasCreator web app to export SVG from the JSON file."
+  };
+}
+
+function resolveStartLocale(options = {}) {
+  const explicitLocale = options.locale;
+  const defaultLocale = options["default-locale"] || methodEngine.DEFAULT_LOCALE;
+  if (explicitLocale) {
+    return explicitLocale;
+  }
+
+  return methodEngine.getSupportedMethodLocales().includes(defaultLocale)
+    ? defaultLocale
+    : methodEngine.DEFAULT_LOCALE;
+}
+
+async function maybePromptForStartLocale(options = {}) {
+  const selectedLocale = resolveStartLocale(options);
+  if (
+    options.locale ||
+    options.json ||
+    options.list ||
+    options.answers ||
+    !process.stdin.isTTY
+  ) {
+    return selectedLocale;
+  }
+
+  const supportedLocales = methodEngine.getSupportedMethodLocales();
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+
+  try {
+    console.log(`Default method language: ${selectedLocale}`);
+    console.log(`Available languages: ${supportedLocales.join(", ")}`);
+    const answer = (await rl.question("Press Enter to keep the default, or type another locale for this run: "))
+      .trim()
+      .toLowerCase();
+    if (!answer) {
+      console.log("");
+      return selectedLocale;
+    }
+
+    if (supportedLocales.includes(answer)) {
+      console.log("");
+      return answer;
+    }
+
+    console.log(`Unknown locale "${answer}", using ${selectedLocale}.`);
+    console.log("");
+    return selectedLocale;
+  } finally {
+    rl.close();
+  }
+}
+
+function formatCommandFailure(result) {
+  if (result.error?.message) {
+    return result.error.message;
+  }
+
+  const stderr = String(result.stderr || "").trim();
+  if (stderr) {
+    return stderr;
+  }
+
+  const stdout = String(result.stdout || "").trim();
+  if (stdout) {
+    return stdout;
+  }
+
+  return "Canvas export failed.";
 }
 
 function exportCanvasSvgForResource(stationId, step, locale, output) {
   const jsonPath = methodEngine.generateCanvasForStationResource(stationId, step.resourceId, locale, output);
   const exportCommand = resolveCanvasExportCommand();
-  if (!exportCommand) {
+  if (!exportCommand.ok) {
     return {
       ok: false,
-      reason: "CanvasCreator export CLI is not installed in this project yet.",
+      reason: exportCommand.reason,
+      help: exportCommand.help,
       jsonPath
     };
   }
 
   const outputDir = path.dirname(jsonPath);
   const outputFile = path.join(outputDir, `${step.resourceId}.svg`);
-  const result = spawnSync(
+  const result = runCommand(
     exportCommand.command,
     [
       ...exportCommand.args,
@@ -201,16 +303,14 @@ function exportCanvasSvgForResource(stationId, step, locale, output) {
       "--output", outputFile
     ],
     {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      shell: process.platform === "win32"
+      cwd: process.cwd()
     }
   );
 
   if (result.status !== 0) {
     return {
       ok: false,
-      reason: result.stderr || result.stdout || "Canvas export failed.",
+      reason: formatCommandFailure(result),
       jsonPath
     };
   }
@@ -562,6 +662,9 @@ async function runInteractiveResources(options) {
             console.log(`Source JSON: ${exportResult.jsonPath}`);
           } else {
             console.log(`SVG export unavailable: ${exportResult.reason}`);
+            if (exportResult.help) {
+              console.log(exportResult.help);
+            }
             console.log(`Canvas JSON is still available at: ${exportResult.jsonPath}`);
             console.log(`CanvasCreator URL: ${methodEngine.getCanvasCreatorUrl(step.canvasId, locale)}`);
           }
@@ -627,7 +730,8 @@ async function main() {
   }
 
   if (command === "start") {
-    const data = methodEngine.buildStartData(options.locale || methodEngine.DEFAULT_LOCALE);
+    const locale = await maybePromptForStartLocale(options);
+    const data = methodEngine.buildStartData(locale);
     if (options.json) {
       console.log(JSON.stringify(data, null, 2));
       return;
@@ -638,7 +742,7 @@ async function main() {
       return;
     }
 
-    await runInteractiveStart(data, options);
+    await runInteractiveStart(data, { ...options, locale });
     return;
   }
 

--- a/packages/create-apiops/package.json
+++ b/packages/create-apiops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-apiops",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Scaffold a new APIOps project with an OpenAPI spec, audit scaffolding, and APIOps documentation templates.",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/test-create-apiops-scaffold.mjs
+++ b/scripts/test-create-apiops-scaffold.mjs
@@ -59,6 +59,10 @@ try {
   assert(pkg.name === projectName, "Scaffolded package name was not set correctly.");
   assert(pkg.scripts?.method, "Expected generic method script in scaffolded package.");
   assert(pkg.scripts?.["method:start"], "Expected method:start script in scaffolded package.");
+  assert(
+    pkg.scripts["method:start"].includes("--default-locale en"),
+    "Expected method:start to pass the project default locale without forcing the runtime locale."
+  );
   assert(pkg.scripts?.["method:resources:strategy"], "Expected method:resources:strategy script in scaffolded package.");
   assert(pkg.scripts?.["method:canvases:new-api"], "Expected method:canvases:new-api script in scaffolded package.");
   assert(pkg.scripts?.["method:stations"], "Expected method:stations script in scaffolded package.");

--- a/scripts/test-method-cli.mjs
+++ b/scripts/test-method-cli.mjs
@@ -1,0 +1,123 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import * as methodEngine from "../src/lib/method-engine.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+const methodCliPath = resolve(repoRoot, "packages/create-apiops/bin/method-cli.js");
+const scaffoldCliPath = resolve(repoRoot, "packages/create-apiops/bin/create-apiops-project.js");
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const tempRoot = mkdtempSync(join(tmpdir(), "method-cli-test-"));
+
+try {
+  const exportProjectDir = join(tempRoot, "missing-canvascreator");
+  mkdirSync(exportProjectDir, { recursive: true });
+
+  const exportOutput = execFileSync(
+    process.execPath,
+    [
+      methodCliPath,
+      "resources",
+      "--station", "api-product-strategy",
+      "--locale", "en",
+      "--output", "./specs/canvases",
+      "--step-actions", "5,8"
+    ],
+    {
+      cwd: exportProjectDir,
+      encoding: "utf8"
+    }
+  );
+
+  assert(
+    exportOutput.includes("SVG export unavailable: SVG export requires CanvasCreator export support, which is not installed in this project."),
+    "Expected a friendly missing-install SVG export message."
+  );
+  assert(
+    exportOutput.includes("Run `npm install` to install project dependencies, or `npm install canvascreator` to add CanvasCreator manually."),
+    "Expected SVG export help text when CanvasCreator is missing."
+  );
+  assert(
+    !exportOutput.includes("is not recognized as an internal or external command"),
+    "Did not expect raw Windows shell errors in SVG export output."
+  );
+
+  const supportedLocales = methodEngine.getSupportedMethodLocales();
+  assert(
+    JSON.stringify(supportedLocales) === JSON.stringify(["en", "de", "fi", "fr", "pt"]),
+    "Expected supported method locales to match the locale folders."
+  );
+
+  const finnishStartData = methodEngine.buildStartData("fi");
+  const startOutputFi = execFileSync(
+    process.execPath,
+    [
+      methodCliPath,
+      "start",
+      "--locale", "fi",
+      "--answers", "no",
+      "--next-action", "exit"
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }
+  );
+
+  assert(
+    startOutputFi.includes(`Recommended start station: ${finnishStartData[0].title} (${finnishStartData[0].id})`),
+    "Expected `start --locale fi` to use Finnish output."
+  );
+  assert(
+    !startOutputFi.includes("Default method language:"),
+    "Did not expect the locale prompt when --locale is explicitly provided."
+  );
+
+  const startListOutput = execFileSync(
+    process.execPath,
+    [
+      methodCliPath,
+      "start",
+      "--default-locale", "fi",
+      "--list"
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }
+  );
+
+  assert(
+    startListOutput.includes(finnishStartData[0].title),
+    "Expected non-interactive start output to use the default locale."
+  );
+  assert(
+    !startListOutput.includes("Default method language:"),
+    "Did not expect the locale prompt in list mode."
+  );
+
+  const methodCliSource = readFileSync(methodCliPath, "utf8");
+  const scaffoldCliSource = readFileSync(scaffoldCliPath, "utf8");
+  assert(
+    !methodCliSource.includes("shell: process.platform === \"win32\""),
+    "Expected method CLI export execution to avoid shell-based Windows spawning."
+  );
+  assert(
+    !scaffoldCliSource.includes("shell: true"),
+    "Expected scaffold CLI to avoid shell:true child process execution."
+  );
+
+  console.log("method CLI regression test passed.");
+} finally {
+  rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/src/lib/method-engine.js
+++ b/src/lib/method-engine.js
@@ -237,6 +237,33 @@ export function getStations() {
     .sort((left, right) => left.order - right.order);
 }
 
+export function getSupportedMethodLocales() {
+  if (!fs.existsSync(resolveMethodFile())) {
+    return [DEFAULT_LOCALE];
+  }
+
+  const locales = fs.readdirSync(resolveMethodFile(), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((locale) => fs.existsSync(resolveMethodFile(locale, "labels.stations.json")));
+
+  if (!locales.includes(DEFAULT_LOCALE)) {
+    locales.unshift(DEFAULT_LOCALE);
+  }
+
+  return locales
+    .slice()
+    .sort((left, right) => {
+      if (left === DEFAULT_LOCALE) {
+        return -1;
+      }
+      if (right === DEFAULT_LOCALE) {
+        return 1;
+      }
+      return left.localeCompare(right);
+    });
+}
+
 export function getStationCriteriaMap() {
   return readJson(resolveMethodFile("station-criteria.json"));
 }


### PR DESCRIPTION
Update the CLI so the canvas export option fails early and clearly when CanvasCreator export support is not installed, never attempts a shell-based spawn on Windows for that case, and no longer emits DEP0190 from child-process usage. 

Extend method:start so a freshly scaffolded project can offer a one-time language choice at startup while still honoring the project’s default locale.